### PR TITLE
Pass pvc size to deployment

### DIFF
--- a/k8s-files/pvc-webhook.yaml
+++ b/k8s-files/pvc-webhook.yaml
@@ -23,6 +23,9 @@ spec:
             - --port=9093
             - --tls-crt=/etc/webhook/certs/tls.crt
             - --tls-key=/etc/webhook/certs/tls.key
+          env:
+            - name: MAX_PVC_SIZE_BYTES
+              value: "5368709120"  # 5 GiB in bytes (5 * 1024^3)
           ports:
             - containerPort: 9093
               name: webhook

--- a/pvc-webhook-code/main.go
+++ b/pvc-webhook-code/main.go
@@ -9,6 +9,8 @@ import (
     "io"
     "log"
     "net/http"
+    "os"
+    "strconv"
 
     "golang.org/x/exp/slog"
     admissionv1 "k8s.io/api/admission/v1"
@@ -20,10 +22,10 @@ import (
 )
 
 var (
-    port    int
-    tlsKey  string
-    tlsCert string
-    maxPVCSize int64 = 5 * 1024 * 1024 * 1024 // 5 GiB
+    port       int
+    tlsKey     string
+    tlsCert    string
+    maxPVCSize int64
 )
 
 type PatchOperation struct {
@@ -170,6 +172,20 @@ func main() {
     flag.StringVar(&tlsKey, "tls-key", "/etc/webhook/certs/tls.key", "Private key for TLS")
     flag.StringVar(&tlsCert, "tls-crt", "/etc/webhook/certs/tls.crt", "TLS certificate")
     flag.Parse()
+    
+    // Initialize maxPVCSize from environment variable or default to 5 GiB
+    maxPVCSize = 5 * 1024 * 1024 * 1024 // Default: 5 GiB
+    if maxSizeEnv := os.Getenv("MAX_PVC_SIZE_BYTES"); maxSizeEnv != "" {
+        if parsedSize, err := strconv.ParseInt(maxSizeEnv, 10, 64); err == nil {
+            maxPVCSize = parsedSize
+            slog.Info("using max PVC size from environment", "max_size_bytes", maxPVCSize, "max_size_human", resource.NewQuantity(maxPVCSize, resource.BinarySI).String())
+        } else {
+            slog.Error("invalid MAX_PVC_SIZE_BYTES environment variable, using default", "error", err, "default_size", resource.NewQuantity(maxPVCSize, resource.BinarySI).String())
+        }
+    } else {
+        slog.Info("using default max PVC size", "max_size_bytes", maxPVCSize, "max_size_human", resource.NewQuantity(maxPVCSize, resource.BinarySI).String())
+    }
+    
     slog.Info("loading certs..")
     certs, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
     if err != nil {

--- a/pvc-webhook-code/notes.md
+++ b/pvc-webhook-code/notes.md
@@ -3,3 +3,8 @@ docker build -t pvc-webhook:1.0.0 .
 docker tag pvc-webhook:1.0.0 sebiuo/pvc-webhook:1.0.0
 
 docker push sebiuo/pvc-webhook:1.0.0
+
+## Configuration
+
+The webhook now supports configuring the maximum PVC size via environment variable:
+- `MAX_PVC_SIZE_BYTES`: Maximum allowed PVC size in bytes (default: 5368709120 = 5 GiB)


### PR DESCRIPTION
Make max PVC size configurable via deployment environment variable instead of hardcoding it in Go.

---

[Open in Web](https://www.cursor.com/agents?id=bc-d5f74d57-1d3e-491c-94a6-120e6be5880d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d5f74d57-1d3e-491c-94a6-120e6be5880d)